### PR TITLE
Format display of current task with breaks instead of new lines

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -6,7 +6,6 @@
 
     <script src="/socket.io/socket.io.js"></script>
     <script src="angular.js"></script>
-    <script src="../app.js"></script>
     <script src="service.js"></script>
     <script src="poker.js"></script>
     <link href="bootstrap.css" rel="stylesheet" />
@@ -28,17 +27,20 @@
                     <div class="form-group">
                         <label>Enter your name: </label>
                         <input name="userName" type="text" required ng-model="data.name" />
-                        <button class="btn btn-danger" 
+                        <button class="btn btn-danger"
                                 ng-hide="!params.leader && params.leaderchosen"
-                                ng-click="setLeader()">I'm the leader!</button> 
-                        <button class="btn btn-warning" 
+                                ng-click="setLeader()">I'm the leader!</button>
+                        <button class="btn btn-warning"
                                 ng-hide="!params.leader && params.leaderchosen"
                                 ng-click="resetLeader()">Give up your power</button>
                     </div>
                 </div>
             </form>
             <div class="panel-body">
-                <p>The task being evaluated is: {{params.currenttask || "None"}}</p>
+                <p>The task being evaluated is: </p>
+                <blockquote>
+                  <span ng-repeat-start="line in (params.currenttask || 'None.') | getLines">{{line}}</span><br ng-repeat-end>
+                </blockquote>
             </div>
         </div>
 

--- a/site/poker.js
+++ b/site/poker.js
@@ -50,8 +50,8 @@ app.controller("MainCtrl", function ($scope, socket) {
 
     socket.on('onLeaderReset', function () {
         $scope.params.leaderchosen = false;
-    })
-    
+    });
+
     // Outgoing
     $scope.createCard = function (data) {
         $scope.cardchoices.push(data);
@@ -84,7 +84,7 @@ app.controller("MainCtrl", function ($scope, socket) {
     $scope.changeCards = function (data) {
         $scope.cardoptions = $scope.parseCards(data);
         socket.emit('onCardsChanged', data);
-    }
+    };
 
     $scope.setLeader = function () {
         $scope.params.leader = true;
@@ -134,6 +134,12 @@ app.controller("MainCtrl", function ($scope, socket) {
             return cards;
         }
     };
+});
+
+app.filter('getLines', function() {
+  return function(input) {
+    return input.split('\n');
+  }
 });
 
 // })();


### PR DESCRIPTION
Added a filter to split the incoming current task by lines so that the output for each user would match what the leader input into the text area.
